### PR TITLE
Писать в UTF-8 без BOM

### DIFF
--- a/src/Serilog.Sinks.ElkStreams/Serilog.Sinks.ElkStreams.csproj
+++ b/src/Serilog.Sinks.ElkStreams/Serilog.Sinks.ElkStreams.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog sink for ElkStreams</Description>
-    <VersionPrefix>1.2.6</VersionPrefix>
+    <VersionPrefix>1.2.7</VersionPrefix>
     <Authors>Yury Pliner</Authors>
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.ElkStreams</AssemblyName>

--- a/src/Serilog.Sinks.ElkStreams/Sinks/ElkStreams/ElkStreamsSink.cs
+++ b/src/Serilog.Sinks.ElkStreams/Sinks/ElkStreams/ElkStreamsSink.cs
@@ -67,7 +67,7 @@ namespace Serilog.Sinks.ElkStreams
             _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(ElkStreamsApi.AuthorizationScheme, apiKey);
             _formatter = new ElkStreamsJsonFormatter(renderMessage: renderMessage);
             _eventsStream = new MemoryStream();
-            _eventsWriter = new StreamWriter(_eventsStream, Encoding.UTF8, EventSize);
+            _eventsWriter = new StreamWriter(_eventsStream, new UTF8Encoding(false, true), EventSize);
         }
 
         /// <summary>


### PR DESCRIPTION
В ELK не пишется первый лог после старта приложения из-за того, что вначале **StreamWriter** с кодировкой **Encoding.UTF8** добавляет 3 байта BOM. 

Явно создал экземпляр **UTF8Encoding** без BOM. 

Точно такой же используется по умолчанию в **StreamWriter**, если не задан явно.